### PR TITLE
instantpage: add LibreJS license label

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -1,4 +1,5 @@
 /*! instant.page v1.0.0 - (C) 2019 Alexandre Dieulot - https://instant.page/license */
+// @license magnet:?xt=urn:btih:d3d9a9a6595521f9666a5e94cc830dab83b65699&dn=expat.txt MIT/Expat
 
 let urlToPreload
 let mouseoverTimer
@@ -122,3 +123,5 @@ function stopPreloading() {
   * but Firefox 64 interprets it as a relative URL to prefetch. */
   prefetcher.removeAttribute('href')
 }
+
+// @license-end


### PR DESCRIPTION
This allows users who have LibreJS installed to be able to take
advantage of instant.page, by tagging the code as being under the
MIT/Expat license. For more information see [1].

[1]: https://www.gnu.org/software/librejs/free-your-javascript.html

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>