### PR TITLE
Check that a href element exists

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -91,6 +91,10 @@ function isPreloadable(linkElement) {
   if (urlToPreload == linkElement.href) {
     return
   }
+  
+  if(!linkElement.href || linkElement.href.length == 0 ||  linkElement.href == '#') {
+    return
+  }
 
   const urlObject = new URL(linkElement.href)
 


### PR DESCRIPTION
Following up from Issue #11 

Ensure that instantclick ignores <a> tags that do not have a href attribute (which is valid HTML as per the link below).

https://www.w3.org/TR/2016/REC-html51-20161101/textlevel-semantics.html#the-a-element