### PR TITLE
Various changes

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -86,6 +86,10 @@ function isPreloadable(linkElement) {
     return
   }
 
+  if (linkElement.href.indexOf('#') === 0) {
+    return
+  }
+
   if (urlToPreload === linkElement.href) {
     return
   }

--- a/instantpage.js
+++ b/instantpage.js
@@ -90,6 +90,10 @@ function isPreloadable(linkElement) {
     return
   }
 
+  if ('noInstant' in linkElement.dataset) {
+    return
+  }
+
   if (urlToPreload === linkElement.href) {
     return
   }
@@ -113,10 +117,6 @@ function isPreloadable(linkElement) {
   }
 
   if (preloadLocation.hash && preloadLocation.pathname + preloadLocation.search === location.pathname + location.search) {
-    return
-  }
-
-  if ('noInstant' in linkElement.dataset) {
     return
   }
 

--- a/instantpage.js
+++ b/instantpage.js
@@ -67,7 +67,7 @@ function mouseoverListener(event) {
 }
 
 function mouseoutListener(event) {
-  if (event.relatedTarget && event.target.closest('a') == event.relatedTarget.closest('a')) {
+  if (event.relatedTarget && event.target.closest('a') === event.relatedTarget.closest('a')) {
     return
   }
 
@@ -86,13 +86,13 @@ function isPreloadable(linkElement) {
     return
   }
 
-  if (urlToPreload == linkElement.href) {
+  if (urlToPreload === linkElement.href) {
     return
   }
 
   const preloadLocation = new URL(linkElement.href)
 
-  if (!allowExternalLinks && preloadLocation.origin != location.origin && !('instant' in linkElement.dataset)) {
+  if (!allowExternalLinks && preloadLocation.origin !== location.origin && !('instant' in linkElement.dataset)) {
     return
   }
 
@@ -100,7 +100,7 @@ function isPreloadable(linkElement) {
     return
   }
 
-  if (preloadLocation.protocol == 'http:' && location.protocol == 'https:') {
+  if (preloadLocation.protocol === 'http:' && location.protocol === 'https:') {
     return
   }
 
@@ -108,7 +108,7 @@ function isPreloadable(linkElement) {
     return
   }
 
-  if (preloadLocation.hash && preloadLocation.pathname + preloadLocation.search == location.pathname + location.search) {
+  if (preloadLocation.hash && preloadLocation.pathname + preloadLocation.search === location.pathname + location.search) {
     return
   }
 


### PR DESCRIPTION
This pull request consist of 3 commits.

#### Use strict equality comparison
Change comparison operators to strict.

#### Prevent preload if href starts with hash
Prevent links like `<a href="#top">Go to top</a>` preloading.

#### Check for 'noInstant' in dataset earlier in evaluation
Move check for `noInstant` in dataset up within the `isPreloadable` function. Makes more sense, and saves from some evaluation.