### PR TITLE
Change closure syntax for older browsers

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -88,7 +88,7 @@ function mouseoverListener(event) {
 
   urlToPreload = linkElement.href
 
-  mouseoverTimer = setTimeout(() => {
+  mouseoverTimer = setTimeout(function() {
     preload(linkElement.href)
     mouseoverTimer = undefined
   }, delayOnHover)


### PR DESCRIPTION
Although this package is not meant to be working for older browsers who don't have preload support. It does error out on older browsers like for example Internet Explorer 11.

To avoid breaking websites on IE 11 while using this package, we need to change the closure syntax to avoid parse errors and that Javascript won't be evaluated further in these browsers. Hereby I changed it, and with this syntax I get no errors in IE 11.