### PR TITLE
Fix for NaN comparison

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -23,7 +23,7 @@ if ('instantIntensity' in document.body.dataset) {
   }
   else {
     const milliseconds = parseInt(document.body.dataset.instantIntensity)
-    if (milliseconds != NaN) {
+    if (!isNaN(milliseconds)) {
       delayOnHover = milliseconds
     }
   }


### PR DESCRIPTION
`milliseconds != NaN` at line 26 was always true.