### PR TITLE
Check online status before prefetching URLs

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -6,6 +6,7 @@ const prefetches = new Set()
 const prefetchElement = document.createElement('link')
 const isSupported = prefetchElement.relList && prefetchElement.relList.supports && prefetchElement.relList.supports('prefetch')
                     && window.IntersectionObserver && 'isIntersecting' in IntersectionObserverEntry.prototype
+const isOnline = () => window.navigator.onLine
 const allowQueryString = 'instantAllowQueryString' in document.body.dataset
 const allowExternalLinks = 'instantAllowExternalLinks' in document.body.dataset
 const useWhitelist = 'instantWhitelist' in document.body.dataset
@@ -223,6 +224,10 @@ function isPreloadable(linkElement) {
 }
 
 function preload(url) {
+  if (!isOnline()) {
+        return
+  }
+  
   if (prefetches.has(url)) {
     return
   }


### PR DESCRIPTION
Related to issue #73

As a website owner, I want to only prefetch URLs when I am online, so that I am not getting network errors when my site is offline or served by a service-worker.

Changes:

- Implement isOnline function to check online status via navigator.onLine (https://developer.mozilla.org/de/docs/Web/API/NavigatorOnLine/onLine).
- Implement guard in preload function to check online status with this function.

Only tested on my setup. Has to be tested on larger scope before merging.