### PR TITLE
Add options to modify URL and link element

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -232,6 +232,10 @@ function isPreloadable(linkElement) {
 }
 
 function preload(url) {
+  if (typeof instantUrlModifier === 'function') {
+    url = instantUrlModifier(url);
+  }
+
   if (prefetches.has(url)) {
     return
   }
@@ -239,6 +243,9 @@ function preload(url) {
   const prefetcher = document.createElement('link')
   prefetcher.rel = 'prefetch'
   prefetcher.href = url
+  if (typeof instantLinkModifier === 'function') {
+    instantLinkModifier(prefetcher);
+  }
   document.head.appendChild(prefetcher)
 
   prefetches.add(url)


### PR DESCRIPTION
This supports prefetching of other sites without revealing the user's IP or cookies to them, using signed exchanges. Proof-of-concept at https://github.com/google/sxg-rs/tree/main/distributor (after google/sxg-rs#405).

The proof-of-concept uses:
- instantUrlModifier to modify the URL only on left-click or prefetch, but preserve the original URL for hover (display at the bottom of the browser) and right-click copy
- instantLinkModifier to add `as=document` which is necessary to enable the prefetch cache for some specific cases

But I wrote it generically since it may be useful for other use cases.