### PR TITLE
Use speculation rules prefetch/prerender when available

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -28,7 +28,9 @@ function init() {
 }
 
 async function requestListener(req, res) {
-  const isPrefetched = req.headers['x-moz'] == 'prefetch' /* Firefox 109 */ || req.headers['purpose'] == 'prefetch' /* Chrome 110 & Safari 16.3 */
+  const isPrefetched = req.headers['x-moz'] == 'prefetch' /* Firefox 109 */ ||
+                       req.headers['purpose'] == 'prefetch' /* Chrome 110 & Safari 16.3 */ ||
+                       req.headers['sec-purpose'].startsWith('prefetch') /* Chrome 110 speculation rules */
   const prefetchIndicator = isPrefetched ? 'PF' : ' F'
   const type = req.headers['sec-fetch-dest'] ? req.headers['sec-fetch-dest'].toUpperCase()[0] : '.'
   const spaces = ' '.repeat(Math.max(0, 16 - req.url.length))

--- a/test/tests/hover-long-enough-then-click/2.html
+++ b/test/tests/hover-long-enough-then-click/2.html
@@ -12,6 +12,7 @@ addEventListener('load', async (event) => {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({
       transferSize: navigationPerformanceEntry.transferSize,
+      deliveryType: navigationPerformanceEntry.deliveryType,
     }),
   })
 

--- a/test/tests/hover-long-enough-then-click/config.js
+++ b/test/tests/hover-long-enough-then-click/config.js
@@ -6,5 +6,5 @@ export const environment = {
 }
 
 export function checkExpectation(data) {
-  return data.transferSize === 0
+  return data.transferSize === 0 || data.deliveryType === 'navigational-prefetch'
 }

--- a/test/tests/no-double-download/2.html
+++ b/test/tests/no-double-download/2.html
@@ -12,6 +12,7 @@ addEventListener('load', async (event) => {
     headers: {'Content-Type': 'application/json'},
     body: JSON.stringify({
       transferSize: navigationPerformanceEntry.transferSize,
+      deliveryType: navigationPerformanceEntry.deliveryType,
     }),
   })
 

--- a/test/tests/no-double-download/config.js
+++ b/test/tests/no-double-download/config.js
@@ -6,5 +6,5 @@ export const environment = {
 }
 
 export function checkExpectation(data) {
-  return data.transferSize === 0
+  return data.transferSize === 0 || data.deliveryType === 'navigational-prefetch'
 }


### PR DESCRIPTION
Speculation rules prefetch, currently only available in Chromium-based browsers, has some advantages over `<link rel=prefetch>`:

* It stores the resources in a per-document in-memory cache, instead of in the HTTP cache, which can be slightly faster.

* Because it has its own cache, it is not disabled by HTTP caching headers like Vary or Cache-Control.

* It is automatically integrated into various user-respectful browser settings like Data Saver, Battery Saver, and memory pressure monitoring.

* It has better cross-site support than `<link rel=prefetch>`, including the nonstandard as=document variant, because it disables itself if the destination site has cookies, whereas `<link rel=prefetch>` can cache the wrong version of the document (the version without cookies).

* It shows up nicely in the DevTools speculative loads panel.

The implementation strategy is to just insert a `<script type=speculationrules>` element, with a single list rule pointing to the target URL, instead of inserting the corresponding `<link rel=prefetch>` element.

Additionally, we add the ability to configure prerendering, instead of prerendering, via the `data-instant-specrules=prerender` attribute. (Use of speculation rules can also be turned off, via `data-instant-specrules=no`.) Prerendering is more complex and risky, but can give a significant speed boost.

More information on speculation rules prefetch and prerender is available at https://developer.mozilla.org/en-US/docs/Web/API/Speculation_Rules_API.

When speculation rules are not available, we fall back to `<link rel=prefetch>` as usual.