### PR TITLE
Fix empty anchor

### DIFF
--- a/instantpage.js
+++ b/instantpage.js
@@ -363,6 +363,12 @@ function isPreloadable(anchorElement) {
     return
   }
 
+  // If the href only contains "#", browsers will return empty string instead of "#" when checking anchorElement.hash,
+  // so we have to do an explicit check for it.
+  if (anchorElement.getAttribute('href') === '#') {
+    return;
+  }
+
   if (anchorElement.protocol == 'http:' && location.protocol == 'https:') {
     return
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "instant.page",
+  "version": "5.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "instant.page",
+      "version": "5.2.0",
+      "license": "MIT"
+    }
+  }
+}


### PR DESCRIPTION
This fixes the issue https://github.com/instantpage/instant.page/issues/61

To elaborate, browsers seem to have an odd behavior. If a link has a href set to `#test`, anchorElement.hash will properly return #test. However, if the link is just using `#`, browsers will return empty string instead of `#`, which will cause Instant.Page to preload such links, which is causing some pretty annoying side-effects in our situation.

We might may be also check for `/#`, just to be on the safe side. @dieulot I will let you decide on this :).